### PR TITLE
A better way to automatically load n5550 leds modules

### DIFF
--- a/conf/99-n5550.rules
+++ b/conf/99-n5550.rules
@@ -1,1 +1,0 @@
-ACTION=="add", DEVPATH=="/devices/pci0000:00/0000:00:1f.0/gpio_ich.1.auto/gpio/gpiochip195", RUN+="/usr/sbin/modprobe n5550_board"

--- a/conf/modprobe_n5550.conf
+++ b/conf/modprobe_n5550.conf
@@ -1,4 +1,7 @@
-install n5550_board	/sbin/modprobe i2c_i801; /sbin/modprobe --ignore-install n5550_board
-install	libahci		/sbin/modprobe --ignore-install libahci; /sbin/modprobe n5550_ahci_leds
+softdep libahci	post: n5550_ahci_leds
+# without the second dependency, it is a race condition
+# where n5550_ahci_leds sometimes loses out
+softdep ahci	pre: n5550_ahci_leds
+
 install it87		/sbin/modprobe --ignore-install it87 fix_pwm_polarity=1; echo 1 > /sys/devices/platform/it87.656/pwm3_enable; echo 255 > /sys/devices/platform/it87.656/pwm3
 remove	it87		echo 0 > /sys/devices/platform/it87.656/pwm3_enable; /sbin/modprobe -r --ignore-remove it87

--- a/conf/n5550.modules
+++ b/conf/n5550.modules
@@ -2,7 +2,6 @@
 
 modprobe -b coretemp >/dev/null 2>&1
 modprobe -b it87 >/dev/null 2>&1
-modprobe -b n5550_board >/dev/null 2>&1
 #modprobe -b ledtrig_timer >/dev/null 2>&1
 
 exit 0

--- a/dracut/install
+++ b/dracut/install
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-inst /usr/lib/udev/rules.d/99-n5550.rules

--- a/modules/n5550_ahci_leds.c
+++ b/modules/n5550_ahci_leds.c
@@ -271,6 +271,7 @@ static int __init n5550_ahci_leds_init(void)
 	for (i = 0; i < 5; ++i) {
 		led_trigger_register(&n5550_ahci_led_triggers[i]);
 	}
+	pr_info("leds_n5550_ahci: Successfully installed LED hook\n");
 
 done:
 	mutex_unlock(&module_mutex);

--- a/modules/n5550_board.c
+++ b/modules/n5550_board.c
@@ -22,7 +22,7 @@
 #include <linux/pci.h>
 #include <linux/gpio.h>
 
-#define N5550_ICH_GPIO_BASE_DEFAULT	195
+#define N5550_ICH_GPIO_BASE_DEFAULT	451
 #define N5550_PCA9532_1_GPIO_BASE	16
 #define N5550_BOARD_ID			2
 
@@ -448,6 +448,9 @@ static void __exit n5550_board_exit(void)
 
 module_init(n5550_board_init);
 module_exit(n5550_board_exit);
+
+MODULE_SOFTDEP("pre: i2c_i801");
+MODULE_ALIAS("dmi:bvnPhoenixTechnologiesLtd*:bvrCDV_T??X64:*:pnMilsteadPlatform:*:rnGraniteWell:rvrFABA:*:ct9:*");
 
 MODULE_AUTHOR("Ian Pilcher <arequipeno@gmail.com>");
 MODULE_DESCRIPTION("Thecus N5550 GPIO and LED support");


### PR DESCRIPTION
A simpler way to load the modules automatically. Has been tested on my system for a while.
Actually, i prefer to build my own kernels, so I build the n5550 modules in-tree and also patch ahci.c and libahci.c, so there is no need for a modprobe configuration. But I realize, it's not gonna work for somebody who builds these modules out of tree.
About the change in GPIO base - it switched to 450 around 4.3.y kernels and probably should be left as is if you run something older than this. Or maybe there should be an #ifdef or even if condition - not sure.